### PR TITLE
Add a Mock Spectrometer

### DIFF
--- a/gui/modules/spectrometers.py
+++ b/gui/modules/spectrometers.py
@@ -42,7 +42,7 @@ def gaussian(x, mu, sig):
 
 def halogenSpectrum():
     x = np.linspace(339.24, 1022.28, 2048)
-    return gaussian(x, mu=600, sig=100) + gaussian(x, mu=670, sig=100) * 0.2
+    return gaussian(x, mu=600, sig=100) * 0.7 + gaussian(x, mu=700, sig=70) * 0.3
 
 
 def backgroundSpectrum():

--- a/gui/modules/spectrometers.py
+++ b/gui/modules/spectrometers.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+
+class MockSpectrometer:
+    def __init__(self):
+        self.exposureTime = 3000
+        self.shutter = 0.2
+        self.backgroundIntensity = 0.005
+        self.noise = 0.01
+
+        self._background = backgroundSpectrum()
+        self._source = halogenSpectrum()
+        # todo: move bg and source to spectrum object
+        # todo: calibration offset?
+
+    def integration_time_micros(self, integration_time_micros: int):
+        self.exposureTime = integration_time_micros
+
+    def wavelengths(self) -> np.ndarray:
+        return np.linspace(339.24, 1022.28, 2048)
+
+    def intensities(self) -> np.ndarray:
+        background = self._background * self.backgroundIntensity * self.exposureFactor
+        source = self._source * self.exposureFactor * self.shutterFactor
+        noise = np.random.uniform(0, self.noise, 2048)
+
+        out = (background + source + noise) * 4095
+        return np.clip(out, 0, 4095)
+
+    @property
+    def exposureFactor(self):
+        return self.exposureTime / 3000
+
+    @property
+    def shutterFactor(self):
+        return self.shutter ** 2 / 0.5
+
+
+def gaussian(x, mu, sig):
+    return np.exp(-np.power(x - mu, 2.) / (2 * np.power(sig, 2.)))
+
+
+def halogenSpectrum():
+    x = np.linspace(339.24, 1022.28, 2048)
+    return gaussian(x, mu=600, sig=100) + gaussian(x, mu=670, sig=100) * 0.2
+
+
+def backgroundSpectrum():
+    x = np.linspace(339.24, 1022.28, 2048)
+    return gaussian(x, mu=550, sig=5) * 1 + gaussian(x, mu=610, sig=8) * 0.7 + \
+           gaussian(x, mu=480, sig=15) * 0.2 + gaussian(x, mu=550, sig=200) * 0.1

--- a/gui/views/filterView.py
+++ b/gui/views/filterView.py
@@ -33,6 +33,7 @@ class FilterView(QWidget, Ui_filterView):
         self.dataPlotItem = None
         self.acqWorker = None
         self.spec = None
+        self.waves = None
         self.isAcqAlive = 0
         self.deviceConnected = 0
 
@@ -55,7 +56,7 @@ class FilterView(QWidget, Ui_filterView):
         self.pb_liveView.clicked.connect(self.toggle_liveView)
         self.pb_analyse.clicked.connect(lambda: print("lol compute computer"))
         self.pb_normalize.clicked.connect(lambda: print("lol compute filter"))
-        self.le_exposure.textChanged.connect(lambda: self.spec.integration_time_micros(float(self.le_exposure.text()) * 1000))
+        self.le_exposure.textChanged.connect(lambda: self.spec.integration_time_micros(int(float(self.le_exposure.text()) * 1000)))
 
         log.info("Connecting GUI widgets...")
 
@@ -73,16 +74,15 @@ class FilterView(QWidget, Ui_filterView):
 
     @pyqtSlot(dict)
     def update_graph(self, plotData):
-        x = plotData["x"]
         y = plotData["y"]
-        print(min(x), max(x), min(y), max(y), type(x[0]), type(y[0]), type(x), x.shape)
-        self.dataPlotItem.setData(x, y)
+        self.dataPlotItem.setData(self.waves, y)
 
     def read_data_live(self, *args, **kwargs):
+        self.waves = self.spec.wavelengths()[2:]
+
         while self.isAcqAlive:
-            waves = self.spec.wavelengths()[2:]
             intens = self.spec.intensities()[2:]
-            self.s_data_changed.emit({"x": waves, "y": intens})
+            self.s_data_changed.emit({"y": intens})
 
     def make_threads(self, *args):
         self.acqWorker = Worker(self.read_data_live, *args)
@@ -102,3 +102,4 @@ class FilterView(QWidget, Ui_filterView):
             self.acqThread.terminate()
             self.pb_liveView.stop_flash()
             self.isAcqAlive = False
+

--- a/gui/views/filterView.py
+++ b/gui/views/filterView.py
@@ -5,6 +5,7 @@ from pyqtgraph import PlotItem, BarGraphItem
 from pyqtgraph import GraphicsLayoutWidget
 from PyQt5 import uic
 import seabreeze.spectrometers as sb
+from gui.modules import spectrometers as mock
 from tools.threadWorker import Worker
 
 import logging
@@ -45,12 +46,14 @@ class FilterView(QWidget, Ui_filterView):
         try:
             devices = sb.list_devices()
             self.spec = sb.Spectrometer(devices[0])
-            self.spec.integration_time_micros(float(self.le_exposure.text()) * 1000)
             log.info(devices)
             self.deviceConnected = True
         except IndexError as e:
             log.warning("No SpectrumDevice was found. Try connecting manually.")
             self.deviceConnected = False
+            self.spec = mock.MockSpectrometer()
+
+        self.spec.integration_time_micros(int(float(self.le_exposure.text()) * 1000))
 
     def connect_buttons(self):
         self.pb_liveView.clicked.connect(self.toggle_liveView)
@@ -103,3 +106,7 @@ class FilterView(QWidget, Ui_filterView):
             self.pb_liveView.stop_flash()
             self.isAcqAlive = False
 
+# TODO:
+# integration time (has to a multiple of exposure ( subtract exceed: IT -= IT % ET ))
+# connect (auto), remove background, normalize (take ref, create norm, norm stream)
+# add wavelength line cursor with value display


### PR DESCRIPTION
Automatically connects to the mock spectro if no seabreeze devices are available. 
Includes a background spectrum, a source spectrum (somewhat close-ish to halogen) and noise. 
Output intensity scales with expositionTime (source & background) and lamp shutter (only source). 

Ex. exposure at 30ms, shutter at 0.2
![image](https://user-images.githubusercontent.com/29587649/96327419-6ded0f00-1007-11eb-82d6-10f5dbf2f9ea.png)

Ex. exposure at 300ms, shutter at 0
![image](https://user-images.githubusercontent.com/29587649/96327462-d805b400-1007-11eb-92f6-3d9e4a3bbcb3.png)
